### PR TITLE
amqp-table

### DIFF
--- a/cl-amqp.asd
+++ b/cl-amqp.asd
@@ -17,6 +17,8 @@
                "cl-interpol"
                "wu-decimal"
                "local-time"
+               "collectors"
+               "babel"
                "log4cl")
   :serial t
   :components ((:module "src"
@@ -24,10 +26,12 @@
                 :components
                 ((:file "package")
                  (:file "util/binary-string")
+                 (:file "util/ibuffer")
                  (:module "protocol"
                   :serial t
                   :components
                   ((:file "constants")
                    (:file "conditions")
-                   (:file "frame"))))))
+                   (:file "frame")
+                   (:file "types"))))))
   :in-order-to ((test-op (test-op cl-amqp.test))))

--- a/cl-amqp.asd
+++ b/cl-amqp.asd
@@ -19,6 +19,7 @@
                "local-time"
                "collectors"
                "trivial-utf-8"
+               "fast-io"
                "log4cl")
   :serial t
   :components ((:module "src"
@@ -27,6 +28,7 @@
                 ((:file "package")
                  (:file "util/binary-string")
                  (:file "util/ibuffer")
+                 (:file "util/obuffer")
                  (:module "protocol"
                   :serial t
                   :components

--- a/cl-amqp.asd
+++ b/cl-amqp.asd
@@ -18,7 +18,7 @@
                "wu-decimal"
                "local-time"
                "collectors"
-               "babel"
+               "trivial-utf-8"
                "log4cl")
   :serial t
   :components ((:module "src"

--- a/cl-amqp.test.asd
+++ b/cl-amqp.test.asd
@@ -14,6 +14,7 @@
   :depends-on ("cl-amqp"
                "prove"
                "log4cl"
+               "mw-equiv"
                "cl-interpol")
   :serial t
   :components ((:module "t"
@@ -23,7 +24,8 @@
                  (:test-file "dummy")
                  (:test-file "util/binary-string")
                  (:test-file "conditions")
-                 (:test-file "frame"))))
+                 (:test-file "frame")
+                 (:test-file "types"))))
   :defsystem-depends-on (:prove-asdf)
   :perform (test-op :after (op c)
                     (funcall (intern #.(string :run-test-system) :prove-asdf) c)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,7 +1,7 @@
 (in-package :cl-user)
 
 (defpackage :cl-amqp
-  (:use :cl :alexandria)
+  (:use :cl :alexandria :collectors)
   (:nicknames :amqp)
   (:export :error-type-from-reply-code ;; conditions, maybe auto-generate?
            :amqp-unknown-reply-code-error

--- a/src/protocol/types.lisp
+++ b/src/protocol/types.lisp
@@ -269,8 +269,8 @@ x            Byte array         (D)
 
 (defun amqp-encode-field-value (buffer value)
   (typecase value
-    ;; ((signed-byte 8) (amqp-sb8-table-field-encoder buffer value))
-    ;; ((signed-byte 16) (amqp-sb16-table-field-encoder buffer value))
+    ((signed-byte 8) (amqp-sb8-table-field-encoder buffer value))
+    ((signed-byte 16) (amqp-sb16-table-field-encoder buffer value))
     ((signed-byte 32) (amqp-sb32-table-field-encoder buffer value))
     ((signed-byte 64) (amqp-sb64-table-field-encoder buffer value))
     (double-float (amqp-double-table-field-encoder buffer value))

--- a/src/protocol/types.lisp
+++ b/src/protocol/types.lisp
@@ -2,27 +2,27 @@
 
 ;; cool story -> https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_3
 #|
-  0-9   0-9-1   Qpid/Rabbit  Type               Remarks
+0-9   0-9-1   Qpid/Rabbit  Type               Remarks
 ---------------------------------------------------------------------------
-        t       t            Boolean
-        b       b            Signed 8-bit
-        B                    Unsigned 8-bit
-        U       s            Signed 16-bit      (A1)
-        u                    Unsigned 16-bit
-  I     I       I            Signed 32-bit
-        i                    Unsigned 32-bit
-        L       l            Signed 64-bit      (B)
-        l                    Unsigned 64-bit
-        f       f            32-bit float
-        d       d            64-bit float
-  D     D       D            Decimal            [this one is signed too]
-        s                    Short string       (A2)
-  S     S       S            Long string
-        A       A            Array              (C)
-  T     T       T            Timestamp (u64)
-  F     F       F            Nested Table
-  V     V       V            Void
-                x            Byte array         (D)
+t       t            Boolean
+b       b            Signed 8-bit
+B                    Unsigned 8-bit
+U       s            Signed 16-bit      (A1)
+u                    Unsigned 16-bit
+I     I       I            Signed 32-bit
+i                    Unsigned 32-bit
+L       l            Signed 64-bit      (B)
+l                    Unsigned 64-bit
+f       f            32-bit float
+d       d            64-bit float
+D     D       D            Decimal            [this one is signed too]
+s                    Short string       (A2)
+S     S       S            Long string
+A       A            Array              (C)
+T     T       T            Timestamp (u64)
+F     F       F            Nested Table
+V     V       V            Void
+x            Byte array         (D)
 |#
 
 
@@ -36,7 +36,7 @@
                                      type-name
                                      "+"))
                        (find-package :cl-amqp)))
-             
+
              (amqp-type-decoder-name (type-name)
                (intern (string-upcase ;; TODO: really? what about read-table case?
                         (concatenate 'string "amqp-"
@@ -46,7 +46,7 @@
       `(progn
          ,@(loop for (value name) in types-and-decoders
                  collect `(defconstant ,(amqp-type-constant-name name) ,(char-code value)))
-         (defun amqp-decode-field-value (buffer)
+         (defun amqp-decode-table-field-value (buffer)
            (let ((,type (amqp-decode-field-value-type buffer)))
              (case ,type
                ,@(loop for (value name) in types-and-decoders
@@ -78,7 +78,7 @@
 (defun amqp-sb64-decoder (buffer)
   (ibuffer-decode-sb64 buffer))
 
-(defun amqp-float-decoder (buffer)
+(defun amqp-single-decoder (buffer)
   (ibuffer-decode-float buffer))
 
 (defun amqp-double-decoder (buffer)
@@ -104,19 +104,19 @@
     (apply #'vector
            (loop
              until (ibuffer-consumed-p array-body-buffer)
-             collect (amqp-decode-field-value array-body-buffer)))))
+             collect (amqp-decode-table-field-value array-body-buffer)))))
 
 (defun amqp-timestamp-decoder (buffer)
-  
+
   (let ((time_t (ibuffer-decode-sb64 buffer))) ;; or ub64??
     (local-time:unix-to-timestamp time_t)))
 
-(defun amqp-decode-short-string (buffer)
+(defun amqp-sstring-decoder (buffer)
   (let* ((string-length (ibuffer-decode-ub8 buffer)))
     (ibuffer-decode-utf8 buffer string-length)))
 
-(defun amqp-decode-field-name (buffer)
-  (amqp-decode-short-string buffer))
+(defun amqp-field-name-decoder (buffer)
+  (amqp-sstring-decoder buffer))
 
 (defun amqp-table-decoder (buffer)
   (let* ((table-body-length (ibuffer-decode-ub32 buffer))
@@ -125,24 +125,24 @@
       (loop
         until (ibuffer-consumed-p table-body-buffer)
         do
-           (add-field (amqp-decode-field-name table-body-buffer)
-                      (amqp-decode-field-value table-body-buffer))))))
+           (add-field (amqp-field-name-decoder table-body-buffer)
+                      (amqp-decode-table-field-value table-body-buffer))))))
 
 (defun amqp-void-decoder (buffer)
   (declare (ignore buffer))
   *amqp-void*)
 
-(defun amqp-barray-decoder (buffer)  
+(defun amqp-barray-decoder (buffer)
   (let* ((string-length (ibuffer-decode-ub32 buffer)))
     (ibuffer-get-bytes buffer string-length)))
 
 (define-amqp-types
-  (#\t "boolean")
-  (#\b "sb8")
+    (#\t "boolean")
+    (#\b "sb8")
   (#\s "sb16")
   (#\I "sb32")
   (#\l "sb64")
-  (#\f "float")
+  (#\f "single")
   (#\d "double")
   (#\D "decimal")
   (#\S "lstring")
@@ -152,3 +152,136 @@
   (#\V "void")
   (#\x "barray"))
 
+(defun amqp-encode-field-value-type (buffer type)
+  (obuffer-encode-ub8 buffer type))
+
+(defun amqp-boolean-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-boolean+)
+  (obuffer-encode-ub8 buffer (if value 1 0)))
+
+(defun amqp-sb8-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-sb8+)
+  (obuffer-encode-sb8 buffer value))
+
+(defun amqp-sb16-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-sb16+)
+  (obuffer-encode-sb16 buffer value))
+
+(defun amqp-sb32-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-sb32+)
+  (obuffer-encode-ub32 buffer value))
+
+(defun amqp-sb64-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-sb64+)
+  (obuffer-encode-sb64 buffer value))
+
+(defun amqp-single-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-single+)
+  (obuffer-encode-single buffer value))
+
+(defun amqp-double-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-double+)
+  (obuffer-encode-double buffer value))
+
+(defun amqp-decimal-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-decimal+)
+  (multiple-value-bind (c pow) 
+      (wu-decimal::find-multiplier (denominator value))
+    (obuffer-encode-ub8 buffer pow)
+    (obuffer-encode-sb32 buffer (* (numerator value) c))))
+
+(defun amqp-lstring-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-lstring+)
+  (let ((utf-8-bytes (trivial-utf-8:string-to-utf-8-bytes value)))
+    (obuffer-encode-ub32 buffer (length utf-8-bytes))
+    (obuffer-add-bytes buffer utf-8-bytes)))
+
+(defun amqp-array-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-array+)
+  (let* ((array-buffer (new-obuffer))
+         (array-bytes (loop for item across value
+                            do
+                               (amqp-encode-field-value array-buffer item)
+                            finally
+                               (return (obuffer-get-bytes array-buffer)))))
+    ;; TODO: check (length array-bytes) actually fits ub32
+    (obuffer-encode-ub32 buffer (length array-bytes))
+    (obuffer-add-bytes buffer array-bytes)))
+
+(defun amqp-timestamp-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-timestamp+)
+  (obuffer-encode-sb64 buffer value))
+
+(defun amqp-field-name-encoder (buffer value)
+  (amqp-sstring-encoder buffer value))
+
+(defun amqp-table-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-table+)
+  (amqp-table-encoder buffer value))
+
+(defun amqp-void-table-field-encoder (buffer value)
+  (declare (ignore value))
+  (amqp-encode-field-value-type buffer +amqp-type-void+))
+
+(defun amqp-barray-table-field-encoder (buffer value)
+  (amqp-encode-field-value-type buffer +amqp-type-barray+)
+    ;; TODO: check (length bytes) actually fits ub32
+  (obuffer-encode-ub32 buffer (length value))
+  (obuffer-add-bytes buffer value))
+
+(defun amqp-sstring-encoder (buffer value)
+  (let ((utf-8-bytes (trivial-utf-8:string-to-utf-8-bytes value)))
+    ;; TODO: check (length utf-8-byte) actually fits ub8
+    (obuffer-encode-ub8 buffer (length utf-8-bytes))
+    (obuffer-add-bytes buffer utf-8-bytes)))
+
+(defun amqp-table-encoder (buffer value)
+  (let* ((table-buffer (new-obuffer))
+         (table-bytes (loop for (field-name . field-value) in value
+                            do
+                               (amqp-field-name-encoder table-buffer field-name)
+                               (amqp-encode-field-value table-buffer field-value)
+                            finally
+                               (return (obuffer-get-bytes table-buffer)))))
+    ;; TODO: check (length table-bytes) actually fits ub32
+    (obuffer-encode-ub32 buffer (length table-bytes))
+    (obuffer-add-bytes buffer table-bytes)))
+
+(deftype alist ()
+  `(and list (satisfies list-is-alist)))
+
+(defun list-is-alist (list)
+  (when (typep list 'list)
+    (every #'consp list)))
+
+(deftype void ()
+  `(and symbol (satisfies symbol-is-void)))
+
+(defun symbol-is-void (symbol)
+  (eq :void symbol))
+
+(deftype amqp-boolean ()
+  `(and symbol (satisfies symbol-is-amqp-boolean)))
+
+(defun symbol-is-amqp-boolean (symbol)
+  (or (eq t symbol)
+      (eq :false symbol)))
+
+(defun amqp-encode-field-value (buffer value)
+  (typecase value
+    ;; ((signed-byte 8) (amqp-sb8-table-field-encoder buffer value))
+    ;; ((signed-byte 16) (amqp-sb16-table-field-encoder buffer value))
+    ((signed-byte 32) (amqp-sb32-table-field-encoder buffer value))
+    ((signed-byte 64) (amqp-sb64-table-field-encoder buffer value))
+    (double-float (amqp-double-table-field-encoder buffer value))
+    (float (amqp-single-table-field-encoder buffer value))
+    (wu-decimal:decimal (amqp-decimal-table-field-encoder buffer value))
+    (string (amqp-lstring-table-field-encoder buffer value))
+    (nibbles:simple-octet-vector (amqp-barray-table-field-encoder buffer value))
+    (vector (amqp-array-table-field-encoder buffer value))
+    (local-time:timestamp (amqp-timestamp-table-field-encoder buffer (local-time:timestamp-to-unix value)))
+    (alist (amqp-table-table-field-encoder buffer value))
+    (hash-table (amqp-table-table-field-encoder buffer (hash-table-alist value)))
+    (void (amqp-void-table-field-encoder buffer value))
+    (amqp-boolean (amqp-boolean-table-field-encoder buffer (eq t value)))
+    (t (error "Don't know how to encode ~a" value)))) ;; TODO: specialize error

--- a/src/protocol/types.lisp
+++ b/src/protocol/types.lisp
@@ -1,30 +1,28 @@
 (in-package :cl-amqp)
 
 ;; cool story -> https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_3
-#|
-0-9   0-9-1   Qpid/Rabbit  Type               Remarks
----------------------------------------------------------------------------
-t       t            Boolean
-b       b            Signed 8-bit
-B                    Unsigned 8-bit
-U       s            Signed 16-bit      (A1)
-u                    Unsigned 16-bit
-I     I       I            Signed 32-bit
-i                    Unsigned 32-bit
-L       l            Signed 64-bit      (B)
-l                    Unsigned 64-bit
-f       f            32-bit float
-d       d            64-bit float
-D     D       D            Decimal            [this one is signed too]
-s                    Short string       (A2)
-S     S       S            Long string
-A       A            Array              (C)
-T     T       T            Timestamp (u64)
-F     F       F            Nested Table
-V     V       V            Void
-x            Byte array         (D)
-|#
 
+;;   0-9   0-9-1   Qpid/Rabbit  Type               Remarks
+;; ---------------------------------------------------------------------------
+;;         t       t            Boolean
+;;         b       b            Signed 8-bit
+;;         B                    Unsigned 8-bit
+;;         U       s            Signed 16-bit      (A1)
+;;         u                    Unsigned 16-bit
+;;   I     I       I            Signed 32-bit
+;;         i                    Unsigned 32-bit
+;;         L       l            Signed 64-bit      (B)
+;;         l                    Unsigned 64-bit
+;;         f       f            32-bit float
+;;         d       d            64-bit float
+;;   D     D       D            Decimal            [this one is signed too]
+;;         s                    Short string       (A2)
+;;   S     S       S            Long string
+;;         A       A            Array              (C)
+;;   T     T       T            Timestamp (u64)
+;;   F     F       F            Nested Table
+;;   V     V       V            Void
+;;                 x            Byte array         (D)
 
 ;;; table fields
 
@@ -185,7 +183,7 @@ x            Byte array         (D)
 
 (defun amqp-decimal-table-field-encoder (buffer value)
   (amqp-encode-field-value-type buffer +amqp-type-decimal+)
-  (multiple-value-bind (c pow) 
+  (multiple-value-bind (c pow)
       (wu-decimal::find-multiplier (denominator value))
     (obuffer-encode-ub8 buffer pow)
     (obuffer-encode-sb32 buffer (* (numerator value) c))))
@@ -225,7 +223,7 @@ x            Byte array         (D)
 
 (defun amqp-barray-table-field-encoder (buffer value)
   (amqp-encode-field-value-type buffer +amqp-type-barray+)
-    ;; TODO: check (length bytes) actually fits ub32
+  ;; TODO: check (length bytes) actually fits ub32
   (obuffer-encode-ub32 buffer (length value))
   (obuffer-add-bytes buffer value))
 

--- a/src/protocol/types.lisp
+++ b/src/protocol/types.lisp
@@ -1,0 +1,156 @@
+(in-package :cl-amqp)
+
+;; cool story -> https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_3
+#|
+  0-9   0-9-1   Qpid/Rabbit  Type               Remarks
+---------------------------------------------------------------------------
+        t       t            Boolean
+        b       b            Signed 8-bit
+        B                    Unsigned 8-bit
+        U       s            Signed 16-bit      (A1)
+        u                    Unsigned 16-bit
+  I     I       I            Signed 32-bit
+        i                    Unsigned 32-bit
+        L       l            Signed 64-bit      (B)
+        l                    Unsigned 64-bit
+        f       f            32-bit float
+        d       d            64-bit float
+  D     D       D            Decimal            [this one is signed too]
+        s                    Short string       (A2)
+  S     S       S            Long string
+        A       A            Array              (C)
+  T     T       T            Timestamp (u64)
+  F     F       F            Nested Table
+  V     V       V            Void
+                x            Byte array         (D)
+|#
+
+
+;;; table fields
+
+(defmacro define-amqp-types (&rest types-and-decoders)
+  (with-gensyms (type)
+    (labels ((amqp-type-constant-name (type-name)
+               (intern (string-upcase ;; TODO: really? what about read-table case?
+                        (concatenate 'string "+amqp-type-"
+                                     type-name
+                                     "+"))
+                       (find-package :cl-amqp)))
+             
+             (amqp-type-decoder-name (type-name)
+               (intern (string-upcase ;; TODO: really? what about read-table case?
+                        (concatenate 'string "amqp-"
+                                     type-name
+                                     "-decoder"))
+                       (find-package :cl-amqp))))
+      `(progn
+         ,@(loop for (value name) in types-and-decoders
+                 collect `(defconstant ,(amqp-type-constant-name name) ,(char-code value)))
+         (defun amqp-decode-field-value (buffer)
+           (let ((,type (amqp-decode-field-value-type buffer)))
+             (case ,type
+               ,@(loop for (value name) in types-and-decoders
+                       collect `(,(char-code value) (,(amqp-type-decoder-name name) buffer)))
+               (t (error "Unknown field type ~a" ,type))))))))) ;;TODO: specialize error
+
+(defvar *amqp-boolean-false* nil)
+(defvar *amqp-void* nil)
+
+(defun amqp-decode-field-value-type (buffer)
+  (ibuffer-decode-ub8 buffer))
+
+(defun amqp-boolean-decoder (buffer)
+  (let ((value (ibuffer-decode-ub8 buffer)))
+    (case value
+      (1 t)
+      (0 *amqp-boolean-false*)
+      (t (error "Invalid amqp boolean value ~a" value))))) ;;TODO: specialize error
+
+(defun amqp-sb8-decoder (buffer)
+  (ibuffer-decode-sb8 buffer))
+
+(defun amqp-sb16-decoder (buffer)
+  (ibuffer-decode-sb16 buffer))
+
+(defun amqp-sb32-decoder (buffer)
+  (ibuffer-decode-sb32 buffer))
+
+(defun amqp-sb64-decoder (buffer)
+  (ibuffer-decode-sb64 buffer))
+
+(defun amqp-float-decoder (buffer)
+  (ibuffer-decode-float buffer))
+
+(defun amqp-double-decoder (buffer)
+  (ibuffer-decode-double buffer))
+
+(defun amqp-decimal-decoder (buffer) ;; we decode decimal as ratio see more here: https://wukix.com/lisp-decimals
+  (let ((scale (ibuffer-decode-ub8 buffer))
+        (value (ibuffer-decode-sb32 buffer)))
+    (/ value (expt 10 scale))))
+
+(defun amqp-lstring-decoder (buffer)
+  ;; long strings are just (simple-array (unsinged-byte 8) 1)
+  ;; but rabbitmq also has 'x' - pure byte array fields.
+  ;; and pika fpr example converts lstring to utf8 string
+  ;; I'm lost here
+  ;; (octets-to-string #b"he\x1llo") -> "hello"
+  (let* ((string-length (ibuffer-decode-ub32 buffer))
+         (string-buffer (new-ibuffer buffer string-length)))
+    (babel:octets-to-string (ibuffer-get-bytes string-buffer) :encoding :utf-8)))
+
+(defun amqp-array-decoder (buffer)
+  (let* ((array-body-length (ibuffer-decode-ub32 buffer))
+         (array-body-buffer (new-ibuffer buffer array-body-length)))
+    (apply #'vector
+           (loop
+             until (ibuffer-consumed-p array-body-buffer)
+             collect (amqp-decode-field-value array-body-buffer)))))
+
+(defun amqp-timestamp-decoder (buffer)
+  (let ((time_t (ibuffer-decode-sb64 buffer))) ;; or ub64??
+    (local-time:unix-to-timestamp time_t)))
+
+(defun amqp-decode-short-string (buffer)
+  (let* ((string-length (ibuffer-decode-ub8 buffer))
+         (string-buffer (new-ibuffer buffer string-length)))
+    (babel:octets-to-string (ibuffer-get-bytes string-buffer) :encoding :utf-8)))
+
+(defun amqp-decode-field-name (buffer)
+  (amqp-decode-short-string buffer))
+
+(defun amqp-table-decoder (buffer)
+  (let* ((table-body-length (ibuffer-decode-ub32 buffer))
+         (table-body-buffer (new-ibuffer buffer table-body-length)))
+    (with-alist-output (add-field)
+      (loop
+        until (ibuffer-consumed-p table-body-buffer)
+        do
+           (add-field (amqp-decode-field-name table-body-buffer)
+                      (amqp-decode-field-value table-body-buffer))))))
+
+(defun amqp-void-decoder (buffer)
+  (declare (ignore buffer))
+  *amqp-void*)
+
+(defun amqp-barray-decoder (buffer)  
+  (let* ((string-length (ibuffer-decode-ub32 buffer))
+         (string-buffer (new-ibuffer buffer string-length)))
+    (ibuffer-get-bytes string-buffer)))
+
+(define-amqp-types
+  (#\t "boolean")
+  (#\b "sb8")
+  (#\s "sb16")
+  (#\I "sb32")
+  (#\l "sb64")
+  (#\f "float")
+  (#\d "double")
+  (#\D "decimal")
+  (#\S "lstring")
+  (#\A "array")
+  (#\T "timestamp")
+  (#\F "table")
+  (#\V "void")
+  (#\x "barray"))
+

--- a/src/protocol/types.lisp
+++ b/src/protocol/types.lisp
@@ -96,7 +96,7 @@
   ;; I'm lost here
   ;; (octets-to-string #b"he\x1llo") -> "hello"
   (let* ((string-length (ibuffer-decode-ub32 buffer)))
-    (trivial-utf-8:utf-8-bytes-to-string (ibuffer-get-bytes buffer string-length))))
+    (ibuffer-decode-utf8 buffer string-length)))
 
 (defun amqp-array-decoder (buffer)
   (let* ((array-body-length (ibuffer-decode-ub32 buffer))
@@ -113,7 +113,7 @@
 
 (defun amqp-decode-short-string (buffer)
   (let* ((string-length (ibuffer-decode-ub8 buffer)))
-    (trivial-utf-8:utf-8-bytes-to-string (ibuffer-get-bytes buffer string-length))))
+    (ibuffer-decode-utf8 buffer string-length)))
 
 (defun amqp-decode-field-name (buffer)
   (amqp-decode-short-string buffer))

--- a/src/protocol/types.lisp
+++ b/src/protocol/types.lisp
@@ -95,9 +95,8 @@
   ;; and pika fpr example converts lstring to utf8 string
   ;; I'm lost here
   ;; (octets-to-string #b"he\x1llo") -> "hello"
-  (let* ((string-length (ibuffer-decode-ub32 buffer))
-         (string-buffer (new-ibuffer buffer string-length)))
-    (babel:octets-to-string (ibuffer-get-bytes string-buffer) :encoding :utf-8)))
+  (let* ((string-length (ibuffer-decode-ub32 buffer)))
+    (trivial-utf-8:utf-8-bytes-to-string (ibuffer-get-bytes buffer string-length))))
 
 (defun amqp-array-decoder (buffer)
   (let* ((array-body-length (ibuffer-decode-ub32 buffer))
@@ -108,13 +107,13 @@
              collect (amqp-decode-field-value array-body-buffer)))))
 
 (defun amqp-timestamp-decoder (buffer)
+  
   (let ((time_t (ibuffer-decode-sb64 buffer))) ;; or ub64??
     (local-time:unix-to-timestamp time_t)))
 
 (defun amqp-decode-short-string (buffer)
-  (let* ((string-length (ibuffer-decode-ub8 buffer))
-         (string-buffer (new-ibuffer buffer string-length)))
-    (babel:octets-to-string (ibuffer-get-bytes string-buffer) :encoding :utf-8)))
+  (let* ((string-length (ibuffer-decode-ub8 buffer)))
+    (trivial-utf-8:utf-8-bytes-to-string (ibuffer-get-bytes buffer string-length))))
 
 (defun amqp-decode-field-name (buffer)
   (amqp-decode-short-string buffer))
@@ -134,9 +133,8 @@
   *amqp-void*)
 
 (defun amqp-barray-decoder (buffer)  
-  (let* ((string-length (ibuffer-decode-ub32 buffer))
-         (string-buffer (new-ibuffer buffer string-length)))
-    (ibuffer-get-bytes string-buffer)))
+  (let* ((string-length (ibuffer-decode-ub32 buffer)))
+    (ibuffer-get-bytes buffer string-length)))
 
 (define-amqp-types
   (#\t "boolean")

--- a/src/util/ibuffer.lisp
+++ b/src/util/ibuffer.lisp
@@ -39,11 +39,15 @@
     (advance-cursor source-buffer count)))
 
 (defun ibuffer-get-bytes (ibuffer length)
-  (declare (type ibuffer ibuffer))
+  (declare (type ibuffer ibuffer)
+           (type fixnum length)
+           (optimize (speed 3) (debug 0) (safety 0)))
+  (assert (<= (+ (ibuffer-cursor ibuffer) length)
+              (ibuffer-end ibuffer)))
   (prog1 (subseq (ibuffer-buffer ibuffer)
                  (ibuffer-cursor ibuffer)
                  (+ (ibuffer-cursor ibuffer) length))
-    (advance-cursor ibuffer (- (ibuffer-end ibuffer) (ibuffer-cursor ibuffer)))))
+    (advance-cursor ibuffer length)))
 
 (defun ibuffer-consumed-p (ibuffer)
   (declare (type ibuffer ibuffer))

--- a/src/util/ibuffer.lisp
+++ b/src/util/ibuffer.lisp
@@ -1,0 +1,102 @@
+(in-package :cl-amqp)
+
+(enable-binary-string-syntax)
+
+(defstruct ibuffer
+  (buffer #b"" :type nibbles:simple-octet-vector)
+  (source-buffer)
+  (start 0 :type fixnum)
+  (end 0 :type fixnum)
+  (cursor 0 :type fixnum))
+
+(defun new-ibuffer-from-octets (octets length)
+  (make-ibuffer :buffer octets
+                :start 0
+                :end length
+                :cursor 0))
+
+(defun new-ibuffer-from-ibuffer (ibuffer length)
+  (make-ibuffer :buffer (ibuffer-buffer ibuffer)
+                :source-buffer ibuffer
+                :start (ibuffer-cursor ibuffer)
+                :end (+ (ibuffer-cursor ibuffer) length)
+                :cursor (ibuffer-cursor ibuffer)))
+
+(defun new-ibuffer (source &optional length)
+  (typecase source 
+    (nibbles:simple-octet-vector (new-ibuffer-from-octets source (or length
+                                                                     (length source))))
+    (ibuffer (new-ibuffer-from-ibuffer source (or length
+                                                  (- (ibuffer-end source) (ibuffer-cursor source)))))
+    (t (error "Invalid source for ibuffer")))) ;; TODO: specialize error
+
+(defun advance-cursor (ibuffer count)
+  (declare (type ibuffer ibuffer))
+  (incf (ibuffer-cursor ibuffer) count)
+  (when-let ((source-buffer (ibuffer-source-buffer ibuffer)))
+    (advance-cursor source-buffer count)))
+
+(defun ibuffer-get-bytes (ibuffer)
+  (declare (type ibuffer ibuffer))
+  (prog1 (subseq (ibuffer-buffer ibuffer)
+                 (ibuffer-cursor ibuffer)
+                 (ibuffer-end ibuffer))
+    (advance-cursor ibuffer (- (ibuffer-end ibuffer) (ibuffer-cursor ibuffer)))))
+
+(defun ibuffer-consumed-p (ibuffer)
+  (declare (type ibuffer ibuffer))
+  (>= (ibuffer-cursor ibuffer)
+      (ibuffer-end ibuffer)))
+
+(defun ub8-to-sb8 (byte)
+  (declare (optimize (speed 3) (debug 0) (safety 0))
+           (type (unsigned-byte 8)byte))
+  (if (logbitp 7 byte)
+      (dpb byte (byte 8 0) -1)
+      byte))
+
+(defun ibuffer-decode-ub8 (ibuffer)
+  (declare (type ibuffer ibuffer))
+  (prog1 (aref (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
+    (advance-cursor ibuffer 1)))
+
+(defun ibuffer-decode-sb8 (ibuffer)
+  (declare (type ibuffer ibuffer))
+  (prog1 (ub8-to-sb8 (aref (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer)))
+    (advance-cursor ibuffer 1)))
+
+(defun ibuffer-decode-sb16 (ibuffer)  
+  (declare (type ibuffer ibuffer))
+  (prog1
+      (nibbles:sb16ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
+    (advance-cursor ibuffer 2)))
+
+(defun ibuffer-decode-sb32 (ibuffer)  
+  (declare (type ibuffer ibuffer))
+  (prog1
+      (nibbles:sb32ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
+    (advance-cursor ibuffer 4)))
+
+(defun ibuffer-decode-ub32 (ibuffer)  
+  (declare (type ibuffer ibuffer))
+  (prog1
+      (nibbles:ub32ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
+    (advance-cursor ibuffer 4)))
+
+(defun ibuffer-decode-sb64 (ibuffer)  
+  (declare (type ibuffer ibuffer))
+  (prog1
+      (nibbles:sb64ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
+    (advance-cursor ibuffer 8)))
+
+(defun ibuffer-decode-float (ibuffer)  
+  (declare (type ibuffer ibuffer))
+  (prog1
+      (nibbles:ieee-single-ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
+    (advance-cursor ibuffer 4)))
+
+(defun ibuffer-decode-double (ibuffer)  
+  (declare (type ibuffer ibuffer))
+  (prog1
+      (nibbles:ieee-double-ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
+    (advance-cursor ibuffer 8)))

--- a/src/util/ibuffer.lisp
+++ b/src/util/ibuffer.lisp
@@ -31,16 +31,18 @@
     (t (error "Invalid source for ibuffer")))) ;; TODO: specialize error
 
 (defun advance-cursor (ibuffer count)
-  (declare (type ibuffer ibuffer))
+  (declare (type ibuffer ibuffer)
+           (type fixnum count)
+           (optimize (speed 3) (debug 0) (safety 0)))
   (incf (ibuffer-cursor ibuffer) count)
   (when-let ((source-buffer (ibuffer-source-buffer ibuffer)))
     (advance-cursor source-buffer count)))
 
-(defun ibuffer-get-bytes (ibuffer)
+(defun ibuffer-get-bytes (ibuffer length)
   (declare (type ibuffer ibuffer))
   (prog1 (subseq (ibuffer-buffer ibuffer)
                  (ibuffer-cursor ibuffer)
-                 (ibuffer-end ibuffer))
+                 (+ (ibuffer-cursor ibuffer) length))
     (advance-cursor ibuffer (- (ibuffer-end ibuffer) (ibuffer-cursor ibuffer)))))
 
 (defun ibuffer-consumed-p (ibuffer)
@@ -50,53 +52,61 @@
 
 (defun ub8-to-sb8 (byte)
   (declare (optimize (speed 3) (debug 0) (safety 0))
-           (type (unsigned-byte 8)byte))
+           (type (unsigned-byte 8) byte))
   (if (logbitp 7 byte)
       (dpb byte (byte 8 0) -1)
       byte))
 
 (defun ibuffer-decode-ub8 (ibuffer)
-  (declare (type ibuffer ibuffer))
+  (declare (type ibuffer ibuffer)
+           (optimize (speed 3) (debug 0) (safety 0)))
   (prog1 (aref (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
     (advance-cursor ibuffer 1)))
 
 (defun ibuffer-decode-sb8 (ibuffer)
-  (declare (type ibuffer ibuffer))
+  (declare (type ibuffer ibuffer)
+           (optimize (speed 3) (debug 0) (safety 0)))
   (prog1 (ub8-to-sb8 (aref (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer)))
     (advance-cursor ibuffer 1)))
 
-(defun ibuffer-decode-sb16 (ibuffer)  
-  (declare (type ibuffer ibuffer))
+(defun ibuffer-decode-sb16 (ibuffer)
+  (declare (type ibuffer ibuffer)
+           (optimize (speed 3) (debug 0) (safety 0)))
   (prog1
       (nibbles:sb16ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
     (advance-cursor ibuffer 2)))
 
-(defun ibuffer-decode-sb32 (ibuffer)  
-  (declare (type ibuffer ibuffer))
+(defun ibuffer-decode-sb32 (ibuffer)
+  (declare (type ibuffer ibuffer)
+           (optimize (speed 3) (debug 0) (safety 0)))
   (prog1
       (nibbles:sb32ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
     (advance-cursor ibuffer 4)))
 
-(defun ibuffer-decode-ub32 (ibuffer)  
-  (declare (type ibuffer ibuffer))
+(defun ibuffer-decode-ub32 (ibuffer)
+  (declare (type ibuffer ibuffer)
+           (optimize (speed 3) (debug 0) (safety 0)))
   (prog1
       (nibbles:ub32ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
     (advance-cursor ibuffer 4)))
 
-(defun ibuffer-decode-sb64 (ibuffer)  
-  (declare (type ibuffer ibuffer))
+(defun ibuffer-decode-sb64 (ibuffer)
+  (declare (type ibuffer ibuffer)
+           (optimize (speed 3) (debug 0) (safety 0)))
   (prog1
       (nibbles:sb64ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
     (advance-cursor ibuffer 8)))
 
-(defun ibuffer-decode-float (ibuffer)  
-  (declare (type ibuffer ibuffer))
+(defun ibuffer-decode-float (ibuffer)
+  (declare (type ibuffer ibuffer)
+           (optimize (speed 3) (debug 0) (safety 0)))
   (prog1
       (nibbles:ieee-single-ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
     (advance-cursor ibuffer 4)))
 
-(defun ibuffer-decode-double (ibuffer)  
-  (declare (type ibuffer ibuffer))
+(defun ibuffer-decode-double (ibuffer)
+  (declare (type ibuffer ibuffer)
+           (optimize (speed 3) (debug 0) (safety 0)))
   (prog1
       (nibbles:ieee-double-ref/be (ibuffer-buffer ibuffer) (ibuffer-cursor ibuffer))
     (advance-cursor ibuffer 8)))

--- a/src/util/obuffer.lisp
+++ b/src/util/obuffer.lisp
@@ -1,0 +1,38 @@
+(in-package :cl-amqp)
+
+(defun new-obuffer ()
+  (fast-io:make-output-buffer))
+
+(defun obuffer-get-bytes (buffer)
+  (fast-io:finish-output-buffer buffer))
+
+(defun obuffer-encode-ub8 (buffer value)
+  (fast-io:writeu8-be value buffer))
+
+(defun obuffer-encode-sb8 (buffer value)
+  (fast-io:write8-be value buffer))
+
+(defun obuffer-encode-sb16 (buffer value)
+  (fast-io:write16-be value buffer))
+
+(defun obuffer-encode-sb32 (buffer value)
+  (fast-io:write32-be value buffer))
+
+(defun obuffer-encode-ub32 (buffer value)
+  (fast-io:writeu32-be value buffer))
+
+(defun obuffer-encode-sb64 (buffer value)
+  (fast-io:write64-be value buffer))
+
+(defun obuffer-add-bytes (buffer bytes)
+  (fast-io:fast-write-sequence bytes buffer))
+
+(defun obuffer-encode-single (buffer single)
+  (let ((v (nibbles:make-octet-vector 4)))
+    (setf (nibbles:ieee-single-ref/be v 0) single)
+    (fast-io:fast-write-sequence v buffer)))
+
+(defun obuffer-encode-double (buffer double)
+  (let ((v (nibbles:make-octet-vector 8)))
+    (setf (nibbles:ieee-double-ref/be v 0) double)
+    (fast-io:fast-write-sequence v buffer)))

--- a/t/types.lisp
+++ b/t/types.lisp
@@ -1,0 +1,38 @@
+(in-package :cl-amqp.test)
+
+(plan 1)
+
+(subtest "AMQP Table encode/decode test"
+  (let ((amqp-table-bytes (concatenate '(simple-array  (unsigned-byte 8) 1)
+                                       #b"\x00\x00\x00\xcb"
+                                       #b"\x05arrayA\x00\x00\x00\x0fI\x00\x00\x00\x01I\x00\x00\x00\x02I\x00\x00\x00\x03"
+                                       #b"\x07boolvalt\x01"
+                                       #b"\x07boolval_falset\x00"
+                                       #b"\x07decimalD\x02\x00\x00\x01:"
+                                       #b"\x0bdecimal_tooD\x00\x00\x00\x00d"
+                                       #b"\x07dictvalF\x00\x00\x00\x0c\x03fooS\x00\x00\x00\x03bar"
+                                       #b"\x06intvalI\x00\x00\x00\x01"
+                                       #b"\x07longvall\x00\x00\x00\x006e&U"
+                                       #b"\x04nullV"
+                                       #b"\x06strvalS\x00\x00\x00\x04Test"
+                                       #b"\x0ctimestampvalT\x00\x00\x00\x00Ec)\x92"
+                                       #b"\x07unicodeS\x00\x00\x00\x08utf8=\xe2\x9c\x93"))
+        (table '(("array" . #(1 2 3))
+                 ("boolval" . t)
+                 ("boolval_false" . :false)
+                 ("decimal" . #$3.14)
+                 ("decimal_too" . #$100)
+                 ("dictval" . '(("foo" . "bar")))
+                 ("intval" . 1)
+                 ("longval" . 912598613)
+                 ("null" . nil)
+                 ("strval" . "Test")
+                 ("timestampval" . @2006-11-21T16:30:10)
+                 ("unicode" . "utf8=✓"))))
+
+    (is amqp-table-bytes (with-output-to-buffer (buffer)
+                           (amqp-encode-table table buffer)))
+
+    (is table (amqp-decode-table amqp-table-bytes 0))))
+
+(finalize)

--- a/t/types.lisp
+++ b/t/types.lisp
@@ -36,7 +36,7 @@
                  ("longval" . 912598613)
                  ("null" . :void)
                  ("strval" . "Test")
-                 ("single" . 314)
+                 ("single" . 3.14)
                  ("double" . 3.666666666666d0)
                  ("timestampval" . @2006-11-21T16:30:10)
                  ("unicode" . "utf8=✓"))))

--- a/t/types.lisp
+++ b/t/types.lisp
@@ -11,7 +11,7 @@
 
 (subtest "AMQP Table encode/decode test"
   (let ((amqp-table-bytes (concatenate '(simple-array  (unsigned-byte 8) 1)
-                                       #b"\x00\x00\x00\xcb"
+                                       #b"\x00\x00\x00\xe7"
                                        #b"\x05arrayA\x00\x00\x00\x0fI\x00\x00\x00\x01I\x00\x00\x00\x02I\x00\x00\x00\x03"
                                        #b"\x07boolvalt\x01"
                                        #b"\x0dboolval_falset\x00"
@@ -22,6 +22,8 @@
                                        #b"\x07longvall\x00\x00\x00\x006e&U"
                                        #b"\x04nullV"
                                        #b"\x06strvalS\x00\x00\x00\x04Test"
+                                       #b"\x06singlef\x40\x48\xf5\xc3"
+                                       #b"\x06doubled\x40\xd\x55\x55\x55\x55\x4f\x78"
                                        #b"\x0ctimestampvalT\x00\x00\x00\x00Ec)\x92"
                                        #b"\x07unicodeS\x00\x00\x00\x08utf8=\xe2\x9c\x93"))
         (table '(("array" . #(1 2 3))
@@ -34,6 +36,8 @@
                  ("longval" . 912598613)
                  ("null" . :void)
                  ("strval" . "Test")
+                 ("single" . 314)
+                 ("double" . 3.666666666666d0)
                  ("timestampval" . @2006-11-21T16:30:10)
                  ("unicode" . "utf8=✓"))))
 

--- a/t/types.lisp
+++ b/t/types.lisp
@@ -1,5 +1,12 @@
 (in-package :cl-amqp.test)
 
+(enable-binary-string-syntax)
+(wu-decimal:enable-reader-macro)
+(local-time:enable-read-macros)
+
+(defmethod mw-equiv:object-constituents ((type (eql 'local-time:timestamp)))
+  (list #'local-time:to-rfc1123-timestring))
+
 (plan 1)
 
 (subtest "AMQP Table encode/decode test"
@@ -7,7 +14,7 @@
                                        #b"\x00\x00\x00\xcb"
                                        #b"\x05arrayA\x00\x00\x00\x0fI\x00\x00\x00\x01I\x00\x00\x00\x02I\x00\x00\x00\x03"
                                        #b"\x07boolvalt\x01"
-                                       #b"\x07boolval_falset\x00"
+                                       #b"\x0dboolval_falset\x00"
                                        #b"\x07decimalD\x02\x00\x00\x01:"
                                        #b"\x0bdecimal_tooD\x00\x00\x00\x00d"
                                        #b"\x07dictvalF\x00\x00\x00\x0c\x03fooS\x00\x00\x00\x03bar"
@@ -19,20 +26,23 @@
                                        #b"\x07unicodeS\x00\x00\x00\x08utf8=\xe2\x9c\x93"))
         (table '(("array" . #(1 2 3))
                  ("boolval" . t)
-                 ("boolval_false" . :false)
+                 ("boolval_false". :false)
                  ("decimal" . #$3.14)
                  ("decimal_too" . #$100)
-                 ("dictval" . '(("foo" . "bar")))
+                 ("dictval" . (("foo" . "bar")))
                  ("intval" . 1)
                  ("longval" . 912598613)
-                 ("null" . nil)
+                 ("null" . :void)
                  ("strval" . "Test")
                  ("timestampval" . @2006-11-21T16:30:10)
                  ("unicode" . "utf8=✓"))))
 
-    (is amqp-table-bytes (with-output-to-buffer (buffer)
-                           (amqp-encode-table table buffer)))
-
-    (is table (amqp-decode-table amqp-table-bytes 0))))
+    ;; (is amqp-table-bytes (with-output-to-buffer (buffer)
+    ;;                        (amqp-encode-table table buffer)))
+    
+    (let ((amqp::*amqp-boolean-false* :false)
+          (amqp::*amqp-void* :void))
+      (is table (amqp::amqp-table-decoder (amqp::new-ibuffer amqp-table-bytes)) :test (lambda (x y)
+                                                                                        (mw-equiv:object= x y t))))))
 
 (finalize)

--- a/t/types.lisp
+++ b/t/types.lisp
@@ -11,7 +11,7 @@
 
 (subtest "AMQP Table encode/decode test"
   (let ((amqp-table-bytes (concatenate '(simple-array  (unsigned-byte 8) 1)
-                                       #b"\x00\x00\x01\x09"
+                                       #b"\x00\x00\x01\x1a"
                                        #b"\x05arrayA\x00\x00\x00\x0fI\x00\x00\x00\x01I\x00\x00\x00\x02I\x00\x00\x00\x03"
                                        #b"\x07boolvalt\x01"
                                        #b"\x0dboolval_falset\x00"
@@ -19,7 +19,8 @@
                                        #b"\x0bdecimal_tooD\x00\x00\x00\x00d"
                                        #b"\x07dictvalF\x00\x00\x00\x0c\x03fooS\x00\x00\x00\x03bar"
                                        #b"\x06intvalI\x00\x00\x00\x01"
-                                       #b"\x07longvall\x00\x00\x00\x006e&U"
+                                       #b"\x07longvalI6e&U"
+                                       #b"\x0blonglongvall\x00\x00\x00\x1cu\x03\x1b\x8e"
                                        #b"\x04nullV"
                                        #b"\x06strvalS\x00\x00\x00\x04Test"
                                        #b"\x06singlef\x40\x48\xf5\xc3"
@@ -37,6 +38,7 @@
                  ("dictval" . (("foo" . "bar")))
                  ("intval" . 1)
                  ("longval" . 912598613)
+                 ("longlongval" . 122222222222)
                  ("null" . :void)
                  ("strval" . "Test")
                  ("single" . 3.14)

--- a/t/types.lisp
+++ b/t/types.lisp
@@ -11,7 +11,7 @@
 
 (subtest "AMQP Table encode/decode test"
   (let ((amqp-table-bytes (concatenate '(simple-array  (unsigned-byte 8) 1)
-                                       #b"\x00\x00\x00\xe7"
+                                       #b"\x00\x00\x01\x09"
                                        #b"\x05arrayA\x00\x00\x00\x0fI\x00\x00\x00\x01I\x00\x00\x00\x02I\x00\x00\x00\x03"
                                        #b"\x07boolvalt\x01"
                                        #b"\x0dboolval_falset\x00"
@@ -23,9 +23,12 @@
                                        #b"\x04nullV"
                                        #b"\x06strvalS\x00\x00\x00\x04Test"
                                        #b"\x06singlef\x40\x48\xf5\xc3"
+                                       #b"\x03sb8b\x44"
+                                       #b"\x04sb16s\x4\x44"
                                        #b"\x06doubled\x40\xd\x55\x55\x55\x55\x4f\x78"
                                        #b"\x0ctimestampvalT\x00\x00\x00\x00Ec)\x92"
-                                       #b"\x07unicodeS\x00\x00\x00\x08utf8=\xe2\x9c\x93"))
+                                       #b"\x07unicodeS\x00\x00\x00\x08utf8=\xe2\x9c\x93"
+                                       #b"\x06barrayx\x00\x00\x00\x08utf8=\xe2\x9c\x93"))
         (table '(("array" . #(1 2 3))
                  ("boolval" . t)
                  ("boolval_false". :false)
@@ -37,9 +40,12 @@
                  ("null" . :void)
                  ("strval" . "Test")
                  ("single" . 3.14)
+                 ("sb8" . #x44)
+                 ("sb16" . #x444)
                  ("double" . 3.666666666666d0)
                  ("timestampval" . @2006-11-21T16:30:10)
-                 ("unicode" . "utf8=✓"))))
+                 ("unicode" . "utf8=✓")
+                 ("barray" . #b"utf8=\xe2\x9c\x93"))))
 
     ;; (is amqp-table-bytes (with-output-to-buffer (buffer)
     ;;                        (amqp-encode-table table buffer)))
@@ -47,6 +53,8 @@
     (let ((amqp::*amqp-boolean-false* :false)
           (amqp::*amqp-void* :void))
       (is table (amqp::amqp-table-decoder (amqp::new-ibuffer amqp-table-bytes)) :test (lambda (x y)
-                                                                                        (mw-equiv:object= x y t))))))
+                                                                                        (mw-equiv:object= x y t))))
+    ;; TODO: add error cases
+    ))
 
 (finalize)

--- a/t/types.lisp
+++ b/t/types.lisp
@@ -53,7 +53,17 @@
     (let ((amqp::*amqp-boolean-false* :false)
           (amqp::*amqp-void* :void))
       (is table (amqp::amqp-table-decoder (amqp::new-ibuffer amqp-table-bytes)) :test (lambda (x y)
-                                                                                        (mw-equiv:object= x y t))))
+                                                                                         (mw-equiv:object= x y t))))
+
+    (let ((buffer (amqp::new-obuffer))
+          (amqp::*amqp-boolean-false* :false)
+          (amqp::*amqp-void* :void))
+      (amqp::amqp-table-encoder buffer table)
+      (is
+       table
+       (amqp::amqp-table-decoder (amqp::new-ibuffer (amqp::obuffer-get-bytes buffer)))
+       :test (lambda (x y)
+                (mw-equiv:object= x y t))))
     ;; TODO: add error cases
     ))
 


### PR DESCRIPTION
Amqp table 

[RabbitMQ specific stuff](https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_3)

```
  0-9   0-9-1   Qpid/Rabbit  Type               Remarks
---------------------------------------------------------------------------
        t       t            Boolean
        b       b            Signed 8-bit
        B                    Unsigned 8-bit
        U       s            Signed 16-bit      (A1)
        u                    Unsigned 16-bit
  I     I       I            Signed 32-bit
        i                    Unsigned 32-bit
        L       l            Signed 64-bit      (B)
        l                    Unsigned 64-bit
        f       f            32-bit float
        d       d            64-bit float
  D     D       D            Decimal            [this one is signed too]
        s                    Short string       (A2)
  S     S       S            Long string
        A       A            Array              (C)
  T     T       T            Timestamp (u64)
  F     F       F            Nested Table
  V     V       V            Void
                x            Byte array         (D)
```

Also see [here](https://github.com/rabbitmq/rabbitmq-server/blob/c5dc37f9bb70a2daf95e79cc5248fdc9bbe229fb/src/rabbit_binary_generator.erl#L116) and [here](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/f569efa5f97120fa6944f15fbc8694b8e8d3abb7/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs#L111). Looks like I have to imlement only types form third column
