### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AMQP 0.9.1 with RabbitMQ extensions in Common Lisp
                                                 :payload method))
        (obuffer (amqp:new-obuffer)))
   (amqp:obuffer-get-bytes
-    (amqp:frame-encode frame obuffer)))
+    (amqp:frame-encoder frame obuffer)))
 
 =>
 #b"\x01\x00\x01\x00\x00\x00\x0d\x00<\x00P\x00\x00\x00\x00\x00\x00\x00d\x00\xce"
@@ -26,19 +26,19 @@ AMQP 0.9.1 with RabbitMQ extensions in Common Lisp
        (parser (amqp:make-frame-parser
                 :on-frame-type (lambda (parser frame-type)
                                  (declare (ignore parser))
-                                 (setf frame (make-instance 
+                                 (setf frame (make-instance
                                                (amqp:frame-class-from-frame-type frame-type))))
                 :on-frame-channel (lambda (parser frame-channel)
                                     (declare (ignore parser))
                                     (setf (amqp:frame-channel frame) frame-channel))
                 :on-frame-payload-size (lambda (parser payload-size)
                                          (declare (ignore parser))
-                                         (setf (amqp:frame-size frame) payload-size)
+                                         (setf (amqp:frame-payload-size frame) payload-size)
                                          (setf payload-parser
                                                (amqp:make-frame-payload-parser frame)))
                 :on-frame-payload (lambda (parser data start end)
                                     (declare (ignore parser))
-                                    (amqp:frame-payload-parser-consume payload-parser 
+                                    (amqp:frame-payload-parser-consume payload-parser
                                                                        data :start start :end end))
                 :on-frame-end (lambda (parser)
                                 (declare (ignore parser))
@@ -46,7 +46,7 @@ AMQP 0.9.1 with RabbitMQ extensions in Common Lisp
 
   (amqp:frame-parser-consume parser bytes)
   (amqp:frame-payload frame))
-  
+
 =>
 #<CL-AMQP:AMQP-METHOD-BASIC-ACK {1009C6B703}>
 ```


### PR DESCRIPTION
Fix typos in README.md

amqp:frame-encode -> amqp:frame-encoder
amqp:frame-size -> amqp:frame-payload-size